### PR TITLE
Character name regex update

### DIFF
--- a/magicsim/magicsim/SimcPreloaderData.cs
+++ b/magicsim/magicsim/SimcPreloaderData.cs
@@ -71,7 +71,7 @@ namespace magicsim
                 {
                     Directory.CreateDirectory("characters");
                 }
-                Regex nameRegex = new Regex("(warrior|paladin|hunter|rogue|priest|death knight|shaman|mage|warlock|monk|druid|demon hunter)+=\"?([^\r\n\"]+)\"?");
+                Regex nameRegex = new Regex("(warrior|paladin|hunter|rogue|priest|deathknight|shaman|mage|warlock|monk|druid|demonhunter)+=\"?([^\r\n\"]+)\"?");
                 String name = nameRegex.Match(simcString).Groups[2].Value;
                 if (File.Exists("characters/" + name))
                 {

--- a/magicsim/magicsim/SimcPreloaderData.cs
+++ b/magicsim/magicsim/SimcPreloaderData.cs
@@ -71,8 +71,8 @@ namespace magicsim
                 {
                     Directory.CreateDirectory("characters");
                 }
-                Regex nameRegex = new Regex("[^=]+=\"?([^\r\n\"]+)\"?");
-                String name = nameRegex.Match(simcString).Groups[1].Value;
+                Regex nameRegex = new Regex("(warrior|paladin|hunter|rogue|priest|death knight|shaman|mage|warlock|monk|druid|demon hunter)+=\"?([^\r\n\"]+)\"?");
+                String name = nameRegex.Match(simcString).Groups[2].Value;
                 if (File.Exists("characters/" + name))
                 {
                     File.Delete("characters/" + name);


### PR DESCRIPTION
Matches `{class}=` to find the character name.

Fixes an issue where `blah=` in comments can cause simc string parsing error.

Fixes #7 